### PR TITLE
Add explanatory prompts for ConfirmationQuestions

### DIFF
--- a/src/terra/Command/App/AppRemove.php
+++ b/src/terra/Command/App/AppRemove.php
@@ -49,7 +49,7 @@ class AppRemove extends Command
     }
 
     // Confirm removal of the app.
-    $question = new ConfirmationQuestion("Are you sure you would like to remove the app <question>$name</question>? ", false);
+    $question = new ConfirmationQuestion("Are you sure you would like to remove the app <question>$name</question>? [y/N] ", false);
     if (!$helper->ask($input, $output, $question)) {
       $output->writeln('<error>Cancelled</error>');
       return;

--- a/src/terra/Command/Environment/EnvironmentEnable.php
+++ b/src/terra/Command/Environment/EnvironmentEnable.php
@@ -103,7 +103,7 @@ class EnvironmentEnable extends Command
     $drush_alias_file_path = "{$_SERVER['HOME']}/.drush/{$app_name}.aliases.drushrc.php";
 
     $helper = $this->getHelper('question');
-    $question = new ConfirmationQuestion("Write a drush alias file to <comment>$drush_alias_file_path</comment> ? ", false);
+    $question = new ConfirmationQuestion("Write a drush alias file to <comment>$drush_alias_file_path</comment>? [y/N] ", false);
     if (!$helper->ask($input, $output, $question)) {
       return;
     }

--- a/src/terra/Command/Environment/EnvironmentProxyEnable.php
+++ b/src/terra/Command/Environment/EnvironmentProxyEnable.php
@@ -30,7 +30,7 @@ class EnvironmentProxyEnable extends Command
 
     // Confirm removal of the app.
     $helper = $this->getHelper('question');
-    $question = new ConfirmationQuestion("Run $cmd ?", false);
+    $question = new ConfirmationQuestion("Run $cmd? [y/N] ", false);
     if (!$helper->ask($input, $output, $question)) {
       $output->writeln('<error>Cancelled</error>');
       return;

--- a/src/terra/Command/Environment/EnvironmentRemove.php
+++ b/src/terra/Command/Environment/EnvironmentRemove.php
@@ -80,7 +80,7 @@ class EnvironmentRemove extends Command
     $environment = $app['environments'][$environment_name];
 
     // Confirm removal of the app.
-    $question = new ConfirmationQuestion("Are you sure you would like to remove the environment <question>$app_name:$environment_name</question>?  All files at {$environment['path']} will be deleted, and all containers will be killed.", false);
+    $question = new ConfirmationQuestion("Are you sure you would like to remove the environment <question>$app_name:$environment_name</question>?  All files at {$environment['path']} will be deleted, and all containers will be killed. [y/N] ", false);
     if (!$helper->ask($input, $output, $question)) {
       $output->writeln('<error>Cancelled</error>');
       return;


### PR DESCRIPTION
Added some helpful y/n prompts for the instances of `ConfirmationQuestion`, with the default capitalized.
