### PR TITLE
Remove localhost (make dynamic)

### DIFF
--- a/src/terra/Command/Environment/EnvironmentEnable.php
+++ b/src/terra/Command/Environment/EnvironmentEnable.php
@@ -87,9 +87,10 @@ class EnvironmentEnable extends Command
     $environment_factory = new EnvironmentFactory($environment, $app);
     $output->writeln($environment_factory->enable());
 
+    $ip = $environment_factory->getIp();
     $port = $environment_factory->getPort();
 
-    $app['environments'][$environment_name]['url'] = "http://localhost:$port";
+    $app['environments'][$environment_name]['url'] = "http://$ip:$port";
     $this->getApplication()->getTerra()->getConfig()->add('apps', $app_name, $app);
 
     if ($this->getApplication()->getTerra()->getConfig()->save()) {

--- a/src/terra/Factory/EnvironmentFactory.php
+++ b/src/terra/Factory/EnvironmentFactory.php
@@ -376,8 +376,25 @@ class EnvironmentFactory {
     }
   }
 
+
   /**
-   * Get's the exposed port of the load balancer container.
+   * Gets the correct IP address to reference for Docker
+   * @return string|mixed
+   */
+  public function getIp() {
+    $default_url = "localhost"; // default to localhost
+
+    $process = new Process('docker-machine ip $(docker-machine active)');
+    $process->run();
+    if (!$process->isSuccessful()) {
+      return $default_url;
+    }
+
+    return trim($process->getOutput());
+  }
+
+  /**
+   * Gets the exposed port of the load balancer container.
    * @return bool|mixed
    */
   public function getPort() {
@@ -453,9 +470,9 @@ class EnvironmentFactory {
 
       $factory = new EnvironmentFactory($environment, $this->app);
       $drush_alias_file[] = "\$aliases['{$environment_name}'] = array(";
-      $drush_alias_file[] = "  'uri' => 'localhost:{$factory->getPort()}',";
+      $drush_alias_file[] = "  'uri' => '{$factory->getIp()}:{$factory->getPort()}',";
       $drush_alias_file[] = "  'root' => '/var/www/html',";
-      $drush_alias_file[] = "  'remote-host' => 'localhost',";
+      $drush_alias_file[] = "  'remote-host' => '{$factory->getIp()}',";
       $drush_alias_file[] = "  'remote-user' => 'root',";
       $drush_alias_file[] = "  'ssh-options' => '-p {$factory->getDrushPort()}',";
       $drush_alias_file[] = ");";


### PR DESCRIPTION
Fixes terra-ops/terra-app/issues/31. This needs to be tested on Linux as well. Subsequently, this also fixes an issue on OS X where the generated drush aliases wouldn’t have worked either.

<!---
@huboard:{"order":2.5,"milestone_order":35,"custom_state":""}
-->
