### PR TITLE
Docker containers have restart=always option by default

### DIFF
--- a/src/terra/Factory/EnvironmentFactory.php
+++ b/src/terra/Factory/EnvironmentFactory.php
@@ -287,7 +287,7 @@ class EnvironmentFactory
             'ports' => array(
                 ':80',
             ),
-            'restart' => 'always',
+            'restart' => 'on-failure',
             );
         $compose['app'] = array(
             'image' => 'terra/drupal',
@@ -306,7 +306,7 @@ class EnvironmentFactory
             'expose' => array(
                 '80/tcp',
             ),
-            'restart' => 'always',
+            'restart' => 'on-failure',
             );
             $compose['database'] = array(
                 'image' => 'mariadb',
@@ -318,7 +318,7 @@ class EnvironmentFactory
                     'MYSQL_USER' => 'drupal',
                     'MYSQL_PASSWORD' => 'drupal',
                 ),
-                'restart' => 'always',
+                'restart' => 'on-failure',
         );
         $compose['drush'] = array(
             'image' => 'terra/drush',
@@ -337,7 +337,7 @@ class EnvironmentFactory
             'environment' => array(
                 'AUTHORIZED_KEYS' => $ssh_authorized_keys,
             ),
-            'restart' => 'always',
+            'restart' => 'on-failure',
         );
 
       // Add "app_services": Additional containers linked to the app container.


### PR DESCRIPTION
When I start the computer I see that the terra\* containers are started. I can stop them one by one but they start again after reboot. This happens with the [terra-server](https://github.com/terra-ops/terra-server) as also as any other terra app.

I can see the `restart=always` option on https://github.com/terra-ops/terra-app/blob/master/src/terra/Factory/EnvironmentFactory.php. The default docker option is `restart=no`.
- Do we need this?
- Maybe change it to `restart=on-failure`?

I am applying a patch in case we want to remove the restart policy.
