### PR TITLE
Allow a "yes" option to force run

### DIFF
--- a/src/terra/Console/Application.php
+++ b/src/terra/Console/Application.php
@@ -3,12 +3,23 @@
 namespace terra\Console;
 
 use Symfony\Component\Console\Application as BaseApplication;
+use Symfony\Component\Console\Helper\DialogHelper;
+use Symfony\Component\Console\Helper\DebugFormatterHelper;
+use Symfony\Component\Console\Helper\FormatterHelper;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\ProcessHelper;
+use Symfony\Component\Console\Helper\ProgressHelper;
+use Symfony\Component\Console\Helper\TableHelper;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 use terra\Command;
 use terra\Factory;
 use terra\Terra;
+use terra\TerraQuestionHelper;
 
 /**
  * Class Application.
@@ -56,6 +67,41 @@ class Application extends BaseApplication
 
         return $commands;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDefaultInputDefinition() {
+        return new InputDefinition(array(
+          new InputArgument('command', InputArgument::REQUIRED, 'The command to execute'),
+
+          new InputOption('--help', '-h', InputOption::VALUE_NONE, 'Display this help message'),
+          new InputOption('--quiet', '-q', InputOption::VALUE_NONE, 'Do not output any message'),
+          new InputOption('--verbose', '-v|vv|vvv', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
+          new InputOption('--version', '-V', InputOption::VALUE_NONE, 'Display this application version'),
+          new InputOption('--ansi', '', InputOption::VALUE_NONE, 'Force ANSI output'),
+          new InputOption('--no-ansi', '', InputOption::VALUE_NONE, 'Disable ANSI output'),
+          new InputOption('--yes', '-y', InputOption::VALUE_NONE, 'Answer "yes" to all prompts.'),
+          new InputOption('--no', '-n', InputOption::VALUE_NONE, 'Answer "no" to all prompts.'),
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDefaultHelperSet()
+    {
+        return new HelperSet(array(
+          new FormatterHelper(),
+          new DialogHelper(),
+          new ProgressHelper(),
+          new TableHelper(),
+          new DebugFormatterHelper(),
+          new ProcessHelper(),
+          new TerraQuestionHelper(),
+        ));
+    }
+
 
     /**
      * {@inheritdoc}

--- a/src/terra/TerraQuestionHelper.php
+++ b/src/terra/TerraQuestionHelper.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @file
+ * Overrides Symfony's QuestionHelper to provide --yes and --no options.
+ *
+ * Credit to Platform.sh and platformsh-cli project.
+ */
+
+namespace terra;
+
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class TerraQuestionHelper extends QuestionHelper
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function ask(InputInterface $input, OutputInterface $output, Question $question)
+    {
+        if ($question instanceof ConfirmationQuestion) {
+            $yes = $input->hasOption('yes') && $input->getOption('yes');
+            $no = $input->hasOption('no') && $input->getOption('no');
+            if ($yes && !$no) {
+                return true;
+            }
+            elseif ($no && !$yes) {
+                return false;
+            }
+        }
+        return parent::ask($input, $output, $question);
+    }
+}


### PR DESCRIPTION
PR for #89. This is based off of the work done in platformsh/platformsh-cli#123, which they implemented a --yes and --no option. Any ConfirmationQuestion asked using the helper should used the value of --yes or --no versus its default.
