### PR TITLE
Fixing Docker validation error when enabling environment.

### DIFF
--- a/src/terra/Factory/EnvironmentFactory.php
+++ b/src/terra/Factory/EnvironmentFactory.php
@@ -310,7 +310,7 @@ class EnvironmentFactory
                 '80/tcp',
             ),
             'ports' => array(
-                ':80',
+                80,
             ),
             'restart' => 'on-failure',
         );
@@ -354,7 +354,7 @@ class EnvironmentFactory
                 'database',
             ),
             'ports' => array(
-                ':22',
+                22,
             ),
             'volumes' => array(
                 "$document_root:/var/www/html",


### PR DESCRIPTION
Docker: 1.9.1
Docker Compose: 1.5.1

```
Enable this environment? [y\N] y
DOCKER > Validation failed in file './docker-compose.yml', reason(s):
Service 'drush' configuration key 'ports' '0' contains an invalid type, it should be a number
Service 'load' configuration key 'ports' '0' contains an invalid type, it should be a number
Something went wrong, environment not enabled.
```

The relevant docker compose lines:

```
load:
...
    ports:
        - ':80'
```

and

```
drush:
...
    ports:
        - ':22'
```

This PR simply changes the port mappings to integers as Docker is requesting. Looks like an undocumented (well, besides the above error) change in expectations on Docker's end committed 23 days ago: https://github.com/docker/compose/commit/fa96484d2835b8711e560d0c22626c67b99b2407

Cheers!
