### PR TITLE
Fixing Docker validation error when enabling environment. (dev-fixed-ports)

### DIFF
--- a/src/terra/Factory/EnvironmentFactory.php
+++ b/src/terra/Factory/EnvironmentFactory.php
@@ -270,6 +270,9 @@ class EnvironmentFactory
     {
         $this->getConfig();
 
+        // Determine format for load port
+        $load_port = isset($this->environment->port) ? "{$this->environment->port}:80" : 80;
+
         $source_root = $this->environment->path;
 
         if (!empty($this->config['document_root'])) {
@@ -303,7 +306,7 @@ class EnvironmentFactory
                 '80/tcp',
             ),
             'ports' => array(
-                "{$this->environment->port}:80",
+                $load_port,
             ),
             'restart' => 'on-failure',
         );
@@ -347,7 +350,7 @@ class EnvironmentFactory
                 'database',
             ),
             'ports' => array(
-                ':22',
+                22,
             ),
             'volumes' => array(
                 "$document_root:/var/www/html",


### PR DESCRIPTION
Same as #106 except with a host variable for the load port. Apparently when using a host variable a string works i.e. "80:80", but without i.e. ":80" validation fails and the new validation requires an integer. This PR formats the load port as it's the only port concerned about this format currently.
