### PR TITLE
Interactive .terra.yml creation

### DIFF
--- a/src/terra/Command/Environment/EnvironmentAdd.php
+++ b/src/terra/Command/Environment/EnvironmentAdd.php
@@ -198,7 +198,7 @@ class EnvironmentAdd extends Command
 
         // If yes, gather the necessary info for creating .terra.yml.
         if ($helper->ask($input, $output, $question)) {
-            $question = new Question('Please enter the relative path to your exposed web files: ', '');
+            $question = new Question('Please enter the relative path to your exposed web files: [.] ', '.');
             $document_root = $helper->ask($input, $output, $question);
             $environment->config['document_root'] = $document_root;
 

--- a/src/terra/Command/Environment/EnvironmentAdd.php
+++ b/src/terra/Command/Environment/EnvironmentAdd.php
@@ -187,9 +187,21 @@ class EnvironmentAdd extends Command
     
     /**
      * Help the user create their .terra.yml file.
+     *
+     * @param \Symfony\Component\Console\Input\InputInterface   $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param \terra\Factory\EnvironmentFactory                 $environment
      */
     protected function createTerraYml(InputInterface $input, OutputInterface $output, EnvironmentFactory $environment)
     {
-       $output->writeln('No .terra.yml found. Soon we will help create it for you. For now, See https://github.com/terra-ops/terra-cli/blob/master/docs/.terra.yml');  
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion(
+          'No .terra.yml found. Would you like to create one? [y\N] ', false
+        );
+        if ($helper->ask($input, $output, $question)) {
+            $output->writeln(
+              'This is under construction. In the meantime see: https://github.com/terra-ops/terra-cli/blob/master/docs/.terra.yml'
+            );
+        }
     }
 }

--- a/src/terra/Command/Environment/EnvironmentAdd.php
+++ b/src/terra/Command/Environment/EnvironmentAdd.php
@@ -150,6 +150,11 @@ class EnvironmentAdd extends Command
         if ($environmentFactory->init($path)) {
             // Load config from file.
             $environmentFactory->getConfig();
+            
+            if ($environmentFactory->config == NULL) {
+                // @TODO: If no .terra.yml file is found, offer to create one.
+                $this->createTerraYml($input, $output, $environmentFactory);
+            }
             $environment['document_root'] = isset($environmentFactory->config['document_root']) ? $environmentFactory->config['document_root'] : '';
 
             // Save current branch
@@ -178,5 +183,13 @@ class EnvironmentAdd extends Command
             $input = new ArrayInput($arguments);
             $command->run($input, $output);
         }
+    }
+    
+    /**
+     * Help the user create their .terra.yml file.
+     */
+    protected function createTerraYml(InputInterface $input, OutputInterface $output, EnvironmentFactory $environment)
+    {
+       $output->writeln('No .terra.yml found. Soon we will help create it for you. For now, See https://github.com/terra-ops/terra-cli/blob/master/docs/.terra.yml');  
     }
 }

--- a/src/terra/Command/Environment/EnvironmentAdd.php
+++ b/src/terra/Command/Environment/EnvironmentAdd.php
@@ -198,7 +198,7 @@ class EnvironmentAdd extends Command
 
         // If yes, gather the necessary info for creating .terra.yml.
         if ($helper->ask($input, $output, $question)) {
-            $question = new Question('Please enter the relative path to your exposed web files. ', '');
+            $question = new Question('Please enter the relative path to your exposed web files: ', '');
             $document_root = $helper->ask($input, $output, $question);
             $environment->config['document_root'] = $document_root;
 

--- a/src/terra/Factory/EnvironmentFactory.php
+++ b/src/terra/Factory/EnvironmentFactory.php
@@ -677,4 +677,38 @@ $this->environment->name;
         $process->run();
         return trim($process->getOutput());
     }
+
+    /**
+     * Generates the `terra.yml` file for this environment.
+     *
+     * @return array
+     */
+    public function getTerraYmlContent()
+    {
+        $dumper = new Dumper();
+
+        // A mix of comments and YAML output.
+        $content = "# The relative path to your exposed web files.\n";
+        $input = array('document_root' => $this->config['document_root']);
+        $content .= $dumper->dump($input, 10);
+
+        return $content;
+    }
+
+    /**
+     * Write the terra.yml file.
+     *
+     * @return bool
+     */
+    public function writeTerraYml()
+    {
+        // Create the environment's terra.yml file.
+        $fs = new Filesystem();
+        try {
+            $fs->dumpFile($this->getSourcePath().'/.terra.yml', $this->getTerraYmlContent());
+            return true;
+        } catch (IOExceptionInterface $e) {
+            return false;
+        }
+    }
 }

--- a/src/terra/Factory/EnvironmentFactory.php
+++ b/src/terra/Factory/EnvironmentFactory.php
@@ -679,7 +679,7 @@ $this->environment->name;
     }
 
     /**
-     * Generates the `terra.yml` file for this environment.
+     * Generates the `.terra.yml` file for this environment.
      *
      * @return string
      */
@@ -696,7 +696,7 @@ $this->environment->name;
     }
 
     /**
-     * Write the terra.yml file.
+     * Write the `.terra.yml` file.
      *
      * @return bool
      */

--- a/src/terra/Factory/EnvironmentFactory.php
+++ b/src/terra/Factory/EnvironmentFactory.php
@@ -681,7 +681,7 @@ $this->environment->name;
     /**
      * Generates the `terra.yml` file for this environment.
      *
-     * @return array
+     * @return string
      */
     public function getTerraYmlContent()
     {


### PR DESCRIPTION
As noticed by almost everyone, if your website is in `docroot` or `www` or whatever, you have to have a `.terra.yml` already in your repo for this to work.  @jameswilson finally submitted an issue #114 about it, so let's do it.

It has to have the `document_root: path_to_web` to work.

Obviously, since our goal is to be as **Easy as Possible:tm:**, we want to walk the user through this.

I've created the method to get us started.

Unfortunately, :cry: I have to focus on another project right now... https://github.com/opendevshop/devshop

But i figured, maybe, if I got it started, someone might come by and help? :yellow_heart: 
