### PR TITLE
Ensure URL proxy is running

### DIFF
--- a/src/terra/Command/Environment/EnvironmentEnable.php
+++ b/src/terra/Command/Environment/EnvironmentEnable.php
@@ -4,8 +4,10 @@ namespace terra\Command\Environment;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use terra\Command\Command;
 use terra\Factory\EnvironmentFactory;
@@ -38,6 +40,9 @@ class EnvironmentEnable extends Command
 
         $environment_name = $this->environment->name;
         $app_name = $this->app->name;
+
+        // Ensure that URL Proxy is running and if not offer to enable it.
+        $this->ensureProxy($input, $output);
 
         // Attempt to enable the environment.
         $environment_factory = new EnvironmentFactory($this->environment, $this->app);
@@ -99,6 +104,35 @@ class EnvironmentEnable extends Command
                     echo $buffer;
                 }
             });
+        }
+    }
+
+    /**
+     * Ensure that URL Proxy is running and if not offer to enable it.
+     *
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     */
+    protected function ensureProxy(InputInterface $input, OutputInterface $output)
+    {
+        // Get running containers.
+        $cmd = 'docker ps';
+        $process = new Process($cmd);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+
+        // Look for running instance of URL proxy in `docker ps` output.
+        if (strpos($process->getOutput(), 'jwilder/nginx-proxy')) {
+            $output->writeln('URL Proxy is running.');
+        } else {
+            // Otherwise run the url-proxy:enable command.
+            $output->writeln('Starting URL proxy...');
+            $command = $this->getApplication()->find('url-proxy:enable');
+            $proxyInput = new StringInput('url-proxy:enable');
+            $command->run($proxyInput, $output);
         }
     }
 }

--- a/src/terra/Command/Environment/EnvironmentEnable.php
+++ b/src/terra/Command/Environment/EnvironmentEnable.php
@@ -6,9 +6,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Console\Question\ChoiceQuestion;
 use terra\Command\Command;
 use terra\Factory\EnvironmentFactory;
 
@@ -108,7 +108,7 @@ class EnvironmentEnable extends Command
     }
 
     /**
-     * Ensure that URL Proxy is running and if not offer to enable it.
+     * Ensure that URL proxy is running and if not offer to enable it.
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
@@ -125,14 +125,18 @@ class EnvironmentEnable extends Command
         }
 
         // Look for running instance of URL proxy in `docker ps` output.
-        if (strpos($process->getOutput(), 'jwilder/nginx-proxy')) {
-            $output->writeln('URL Proxy is running.');
-        } else {
-            // Otherwise run the url-proxy:enable command.
-            $output->writeln('Starting URL proxy...');
-            $command = $this->getApplication()->find('url-proxy:enable');
-            $proxyInput = new StringInput('url-proxy:enable');
-            $command->run($proxyInput, $output);
+        if (!strpos($process->getOutput(), 'jwilder/nginx-proxy')) {
+            // If there's no running instance, offer to create one
+            $helper = $this->getHelper('question');
+            $question = new ConfirmationQuestion("URL proxy is not running, would you like to enable it now? [Y/n] ", true);
+            if (!$helper->ask($input, $output, $question)) {
+                $output->writeln('<error>Cancelled</error>');
+            } else {
+                $output->writeln('Starting URL proxy...');
+                $command = $this->getApplication()->find('url-proxy:enable');
+                $proxyInput = new StringInput('url-proxy:enable');
+                $command->run($proxyInput, $output);
+            }
         }
     }
 }

--- a/src/terra/Command/Environment/EnvironmentProxyEnable.php
+++ b/src/terra/Command/Environment/EnvironmentProxyEnable.php
@@ -33,6 +33,7 @@ class EnvironmentProxyEnable extends Command
         } else {
             // We must use the jwilder/nginx-proxy image to allow multiple URLs per docker host.
             $process = new Process($cmd);
+            $process->setTimeout(null);
             $process->run(function ($type, $buffer) {
                 if (Process::ERR === $type) {
                     echo 'DOCKER > '.$buffer;

--- a/src/terra/Command/Environment/EnvironmentProxyEnable.php
+++ b/src/terra/Command/Environment/EnvironmentProxyEnable.php
@@ -4,7 +4,6 @@ namespace terra\Command\Environment;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Process\Process;
 use terra\Command\Command;
 
@@ -23,24 +22,14 @@ class EnvironmentProxyEnable extends Command
         $output->writeln('Hello Terra!');
         $cmd = 'docker run -d -p 80:80 -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy';
 
-        // Confirm removal of the app.
-        $helper = $this->getHelper('question');
-        $question = new ConfirmationQuestion("Run $cmd? [y/N] ", false);
-        if (!$helper->ask($input, $output, $question)) {
-            $output->writeln('<error>Cancelled</error>');
-
-            return;
-        } else {
-            // We must use the jwilder/nginx-proxy image to allow multiple URLs per docker host.
-            $process = new Process($cmd);
-            $process->setTimeout(null);
-            $process->run(function ($type, $buffer) {
-                if (Process::ERR === $type) {
-                    echo 'DOCKER > '.$buffer;
-                } else {
-                    echo 'DOCKER > '.$buffer;
-                }
-            });
-        }
+        $process = new Process($cmd);
+        $process->setTimeout(null);
+        $process->run(function ($type, $buffer) {
+            if (Process::ERR === $type) {
+                echo 'DOCKER > '.$buffer;
+            } else {
+                echo 'DOCKER > '.$buffer;
+            }
+        });
     }
 }


### PR DESCRIPTION
When enabling an environment: checks if the URL proxy container is running. If not then ask the user if they want to create it. If they do then run the `url-proxy:enable` command.

I moved the confirmation message from the `url-proxy:enable` command to the `environment:enable` command with the assumption that if someone is running `url-proxy:enable` then they likely want the container created.

Fixes #20 and also ensures that the url-proxy:enable command doesn't timeout when downloading the docker image.

Example output:

``` shellsession
$ terra env:en dcco 7.x-4.x
URL proxy is not running, would you like to enable it now? [Y/n]
Starting URL proxy...
Hello Terra!
DOCKER > f19a9193f5a58b691c57fe05f609d32d69c1ff30cf20946937fa4b5d21213d78
DOCKER > Starting dcco7x4x_database_1
DOCKER > Starting dcco7x4x_drush_1
DOCKER > Starting dcco7x4x_app_1
DOCKER > Starting dcco7x4x_load_1
Environment enabled!  Available at http://dcco.7.x-4.x.local.computer and http://local.computer:32779
Drush alias file created at /Users/tommy/.drush/dcco.aliases.drushrc.php
Wrote drush alias file to /Users/tommy/.drush/dcco.aliases.drushrc.php
Use drush @terra.dcco.7.x-4.x to access the site.

Running ENABLE app hook...
Sleeping for 5 seconds to let db server start...
```
