### PR TITLE
Fix drush aliases filename.

### DIFF
--- a/src/terra/Command/Environment/EnvironmentEnable.php
+++ b/src/terra/Command/Environment/EnvironmentEnable.php
@@ -70,7 +70,7 @@ class EnvironmentEnable extends Command
         }
 
         // Write drush alias.
-        $drush_alias_file_path = "{$_SERVER['HOME']}/.drush/{$app_name}.aliases.drushrc.php";
+        $drush_alias_file_path = "{$_SERVER['HOME']}/.drush/terra.{$app_name}.aliases.drushrc.php";
         if ($environment_factory->writeDrushAlias()) {
             $output->writeln("<info>Drush alias file created at {$drush_alias_file_path}</info>");
             $output->writeln("Wrote drush alias file to <comment>$drush_alias_file_path</comment>");


### PR DESCRIPTION
@jonpugh this PR is ready for review and merge.

This fixes an inconsistency with the _display_ of the aliases filename in the terminal output of terra once the file is created.
