### PR TITLE
Allow the user to remove an environment's containers but keep the files.

### DIFF
--- a/src/terra/Command/Environment/EnvironmentRemove.php
+++ b/src/terra/Command/Environment/EnvironmentRemove.php
@@ -48,7 +48,7 @@ class EnvironmentRemove extends Command
 
         // Confirm removal of the app.
         if (!$input->getOption('yes')) {
-            $question = new ConfirmationQuestion("Are you sure you would like to remove the environment <question>$app_name:$environment_name</question>?  All files at {$this->environment->path} will be deleted, and all containers will be killed. [y/N] ", false);
+            $question = new ConfirmationQuestion("Are you sure you would like to remove the containers for environment <question>$app_name:$environment_name</question>? [y/N] ", false);
         }
         else {
             $output->writeln("<info>Running with --yes flag. Skipping confirmation step.</info>");
@@ -60,16 +60,19 @@ class EnvironmentRemove extends Command
             // Remove the environment from config registry.
             // @TODO: Move this to EnvironmentFactory class
 
-            // Remove files
-            $fs = new Filesystem();
+            // Remove files if the user wants us to.
+            $question = new ConfirmationQuestion("Would you like to remove all files for environment <question>$app_name:$environment_name</question>? [y/N] ", false);
+            if ($helper->ask($input, $output, $question)) {
+                $fs = new Filesystem();
 
-            try {
-                $fs->remove(array(
-                  $this->environment->path,
-                ));
-                $output->writeln("<info>Files for environment $app_name:$environment_name has been deleted.</info>");
-            } catch (IOExceptionInterface $e) {
-                $output->writeln('<error>Unable to remove '.$e->getPath().'</error>');
+                try {
+                    $fs->remove(array(
+                      $this->environment->path,
+                    ));
+                    $output->writeln("<info>Files for environment $app_name:$environment_name has been deleted.</info>");
+                } catch (IOExceptionInterface $e) {
+                    $output->writeln('<error>Unable to remove '.$e->getPath().'</error>');
+                }
             }
 
             // Destroy the environment

--- a/src/terra/Command/Environment/EnvironmentRemove.php
+++ b/src/terra/Command/Environment/EnvironmentRemove.php
@@ -61,7 +61,7 @@ class EnvironmentRemove extends Command
             // @TODO: Move this to EnvironmentFactory class
 
             // Remove files if the user wants us to.
-            $question = new ConfirmationQuestion("Would you like to remove all files for environment <question>$app_name:$environment_name</question>? [y/N] ", false);
+            $question = new ConfirmationQuestion("Would you like to delete all files at <question>{$this->environment->path}</question>? [y/N] ", false);
             if ($helper->ask($input, $output, $question)) {
                 $fs = new Filesystem();
 
@@ -69,7 +69,7 @@ class EnvironmentRemove extends Command
                     $fs->remove(array(
                       $this->environment->path,
                     ));
-                    $output->writeln("<info>Files for environment $app_name:$environment_name has been deleted.</info>");
+                    $output->writeln("<info>Files for environment $app_name:$environment_name have been deleted.</info>");
                 } catch (IOExceptionInterface $e) {
                     $output->writeln('<error>Unable to remove '.$e->getPath().'</error>');
                 }


### PR DESCRIPTION
I often find myself wanting to remove the current set of containers but leave the files in place, an example would be if I were testing out new .terra.yml/docker-compose configurations. This will only ask if you want to delete the files if you answered yes to removing the containers, or used the --yes flag.

``` shellsession
$ terra env:remove dcco 2016
Are you sure you would like to remove the containers for environment dcco:2016? [y/N] y
Would you like to delete all files at /Users/tommy/Apps/dcco/2016? [y/N]

Running 'docker-compose kill' in /Users/tommy/.terra/environments/dcco/dcco-2016
Killing dcco2016_load_1 ... done
Killing dcco2016_app_1 ... done
Killing dcco2016_drush_1 ... done
Killing dcco2016_database_1 ... done
DOCKER >
Running 'docker-compose rm -f' in /Users/tommy/.terra/environments/dcco/dcco-2016
DOCKER > Not including one-off containers created by `docker-compose run`.
To include them, use `docker-compose rm --all`.
This will be the default behavior in the next version of Compose.

Removing dcco2016_load_1 ... done
Removing dcco2016_app_1 ... done
Removing dcco2016_drush_1 ... done
Removing dcco2016_database_1 ... done
DOCKER > Going to remove dcco2016_load_1, dcco2016_app_1, dcco2016_drush_1, dcco2016_database_1
Environment dcco:2016 has been removed.
```

<img width="772" alt="screenshot 2016-06-10 09 54 34" src="https://cloud.githubusercontent.com/assets/3009533/15970376/84cc38aa-2ef1-11e6-8b3b-ed5765c559ff.png">
