### PR TITLE
Unable to clone large repositories, GitWrapper times out

### DIFF
--- a/src/terra/Factory/EnvironmentFactory.php
+++ b/src/terra/Factory/EnvironmentFactory.php
@@ -58,6 +58,7 @@ class EnvironmentFactory
         // Check if clone already exists at this path. If so we can safely skip.
         if (file_exists($path)) {
             $wrapper = new GitWrapper();
+            $wrapper->setTimeout(3600);
 
             try {
                 $working_copy = new GitWorkingCopy($wrapper, $path);
@@ -81,6 +82,7 @@ class EnvironmentFactory
 
             // Clone repo
             $wrapper = new GitWrapper();
+            $wrapper->setTimeout(3600);
             $wrapper->streamOutput();
             $wrapper->cloneRepository($this->app->repo, $path);
 


### PR DESCRIPTION
Large repositories are reaching timeout on environment:add as default timeout for GitWrapper is 60s which is not enough for a number of large codebases.

```
Cloning into '/Users/username/Apps/Acme/local'...
Unable to clone repository. Check app settings and try again.
```

I propose setting GitWrapper timeout to 3600 to fix it
